### PR TITLE
Remove unneeded lines from bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,8 +5,6 @@ echo "export GOPATH=/gopath" >> /etc/profile.d/gopath.sh
 echo "export PATH=/gopath/bin:\$PATH" >> /etc/profile.d/gopath.sh
 source /etc/profile.d/gopath.sh
 
-mkdir -p /gopath/{bin,pkg,src}
-
 #rpm -Uvh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 
 
@@ -15,8 +13,6 @@ yum install -y golang git mercurial
 #yum install -y python-matplotlib numpy
 
 go get github.com/vektra/mockery
-go install github.com/vektra/mockery
-
 go get github.com/tools/godep
 
 cd /gopath/src/github.com/nvcook42/morgoth/


### PR DESCRIPTION
I'm not sure if the behavior is the same when running with vagrant but /gopath/{bin,pkg,src} are created when doing `go get`.

`go get github.com/vektra/mockery` seems to do the same as `go install github.com/vektra/mockery` on my side.