### PR TITLE
Make all builds static builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
 before_deploy:
   # Build binary
   - go get -u github.com/mitchellh/gox
-  - gox ./cmd/morgoth
+  - CGO_ENABLED=0 gox ./cmd/morgoth
 
 deploy:
   provider: releases


### PR DESCRIPTION
All builds besides the linux_amd64 where already static builds. This change forces all builds to be static independent of the platform performing the compilation. 

Fixes #31 